### PR TITLE
Modify Cinematic Tools' Tooltip

### DIFF
--- a/LaunchGame/LaunchGame/LaunchGame.designer.cs
+++ b/LaunchGame/LaunchGame/LaunchGame.designer.cs
@@ -80,7 +80,7 @@
             this.enableCinematicTools.Size = new System.Drawing.Size(137, 17);
             this.enableCinematicTools.TabIndex = 27;
             this.enableCinematicTools.Text = "Enable Cinematic Tools";
-            this.toolTip1.SetToolTip(this.enableCinematicTools, "Enables HattiWatti\'s Cinematic Tools.\n\nOn some systems, Cinematic Tools may fail to inject.\nAs a workaround, you may manually inject the DLL stored at DATA\\MODTOOLS\\REMOTE_ASSETS\\cinematictools\\CT_AlienIsolation.dll using your injector of choice.");
+            this.toolTip1.SetToolTip(this.enableCinematicTools, "Enables HattiWatti\'s Cinematic Tools.\n\nOn some systems, Cinematic Tools may fail to inject into Alien: Isolation.\nAs a workaround, you may manually inject the DLL stored at DATA\\MODTOOLS\\REMOTE_ASSETS\\cinematictools\\CT_AlienIsolation.dll using your injector of choice.");
             this.enableCinematicTools.UseVisualStyleBackColor = true;
             this.enableCinematicTools.CheckedChanged += new System.EventHandler(this.enableCinematicTools_CheckedChanged);
             // 

--- a/LaunchGame/LaunchGame/LaunchGame.designer.cs
+++ b/LaunchGame/LaunchGame/LaunchGame.designer.cs
@@ -80,7 +80,7 @@
             this.enableCinematicTools.Size = new System.Drawing.Size(137, 17);
             this.enableCinematicTools.TabIndex = 27;
             this.enableCinematicTools.Text = "Enable Cinematic Tools";
-            this.toolTip1.SetToolTip(this.enableCinematicTools, "Enables HattiWatti\'s Cinematic Tools.");
+            this.toolTip1.SetToolTip(this.enableCinematicTools, "Enables HattiWatti\'s Cinematic Tools.\n\nOn some systems, Cinematic Tools may fail to inject.\nAs a workaround, you may manually inject the DLL stored at DATA\\MODTOOLS\\REMOTE_ASSETS\\cinematictools\\CT_AlienIsolation.dll using your injector of choice.");
             this.enableCinematicTools.UseVisualStyleBackColor = true;
             this.enableCinematicTools.CheckedChanged += new System.EventHandler(this.enableCinematicTools_CheckedChanged);
             // 


### PR DESCRIPTION
This wasn't done with the VS WYSIWYG editor so the formatting inside the CS file might be off, but the formatting in the application will be alright.

Here's how the formatting should look like:
```
Enables HattiWatti's Cinematic Tools

On some systems, Cinematic Tools may fail to inject into Alien: Isolation.
As a workaround, you manually inject the DLL stored at DATA\MODTOOLS\REMOTE_ASSETS\cinematictools\CT_AlienIsolation.dll with your injector of choice.
```

I don't think I'm ready to fully disable the option as I'm unsure what circumstances causes it to fail to inject (and neither does the author of Injector).